### PR TITLE
Put more useful information in the voting closed/not open message

### DIFF
--- a/app/day-five/page.tsx
+++ b/app/day-five/page.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button';
 import { useRouter } from 'next/navigation';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { useEffect, useState } from 'react';
+import { isVotingOpenForPosition, ELECTION_SCHEDULE } from '../vote/page'; // Pe987
 
 export default function DayOne() {
     const router = useRouter();
@@ -24,6 +25,28 @@ export default function DayOne() {
 
     const handleVoteClick = (position: string) => {
         router.push(`/vote?position=${encodeURIComponent(position)}`);
+    };
+
+    const getVotingStatusMessage = () => { // Pdd0b
+        const position = 'legal-adviser'; // Example position, adjust as needed
+        if (!position || !ELECTION_SCHEDULE[position.toLowerCase()]) {
+            return "Invalid position";
+        }
+        
+        const schedule = ELECTION_SCHEDULE[position.toLowerCase()];
+        const currentDate = new Date();
+        const votingDate = new Date(currentDate.getFullYear(), 0, schedule.date);
+        const today = new Date();
+        
+        if (today.getDate() === schedule.date && today.getMonth() === 0) {
+            if (!isVotingOpen) {
+                return "Voting is only open from 8 AM to 8 PM";
+            }
+        } else if (today < votingDate) {
+            return `Voting for this position opens on January ${schedule.date}`;
+        } else {
+            return `Voting for this position has ended`;
+        }
     };
 
     return (
@@ -73,7 +96,7 @@ export default function DayOne() {
                     </Button>
                 </div>
             ) : (
-                <p className="text-xl text-center text-red-500">Voting closed/voting not open yet</p>
+                <p className="text-xl text-center text-red-500">{getVotingStatusMessage()}</p> // P89a2
             )}
         </div>
     );

--- a/app/day-four/page.tsx
+++ b/app/day-four/page.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button';
 import { useRouter } from 'next/navigation';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { useEffect, useState } from 'react';
+import { isVotingOpenForPosition, ELECTION_SCHEDULE } from '../vote/page';
 
 export default function DayOne() {
     const router = useRouter();
@@ -24,6 +25,28 @@ export default function DayOne() {
 
     const handleVoteClick = (position: string) => {
         router.push(`/vote?position=${encodeURIComponent(position)}`);
+    };
+
+    const getVotingStatusMessage = () => {
+        const position = 'organizing-secretary'; // Example position, adjust as needed
+        if (!position || !ELECTION_SCHEDULE[position.toLowerCase()]) {
+            return "Invalid position";
+        }
+        
+        const schedule = ELECTION_SCHEDULE[position.toLowerCase()];
+        const currentDate = new Date();
+        const votingDate = new Date(currentDate.getFullYear(), 0, schedule.date);
+        const today = new Date();
+        
+        if (today.getDate() === schedule.date && today.getMonth() === 0) {
+            if (!isVotingOpen) {
+                return "Voting is only open from 8 AM to 8 PM";
+            }
+        } else if (today < votingDate) {
+            return `Voting for this position opens on January ${schedule.date}`;
+        } else {
+            return `Voting for this position has ended`;
+        }
     };
 
     return (
@@ -73,7 +96,7 @@ export default function DayOne() {
                     </Button>
                 </div>
             ) : (
-                <p className="text-xl text-center text-red-500">Voting closed/voting not open yet</p>
+                <p className="text-xl text-center text-red-500">{getVotingStatusMessage()}</p>
             )}
         </div>
     );

--- a/app/day-one/page.tsx
+++ b/app/day-one/page.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button';
 import { useRouter } from 'next/navigation';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { useEffect, useState } from 'react';
+import { isVotingOpenForPosition, ELECTION_SCHEDULE } from '../vote/page';
 
 export default function DayOne() {
     const router = useRouter();
@@ -24,6 +25,28 @@ export default function DayOne() {
 
     const handleVoteClick = (position: string) => {
         router.push(`/vote?position=${encodeURIComponent(position)}`);
+    };
+
+    const getVotingStatusMessage = () => {
+        const position = 'president'; // Example position, adjust as needed
+        if (!position || !ELECTION_SCHEDULE[position.toLowerCase()]) {
+            return "Invalid position";
+        }
+        
+        const schedule = ELECTION_SCHEDULE[position.toLowerCase()];
+        const currentDate = new Date();
+        const votingDate = new Date(currentDate.getFullYear(), 0, schedule.date);
+        const today = new Date();
+        
+        if (today.getDate() === schedule.date && today.getMonth() === 0) {
+            if (!isVotingOpen) {
+                return "Voting is only open from 8 AM to 8 PM";
+            }
+        } else if (today < votingDate) {
+            return `Voting for this position opens on January ${schedule.date}`;
+        } else {
+            return `Voting for this position has ended`;
+        }
     };
 
     return (
@@ -73,7 +96,7 @@ export default function DayOne() {
                     </Button>
                 </div>
             ) : (
-                <p className="text-xl text-center text-red-500">Voting closed/voting not open yet</p>
+                <p className="text-xl text-center text-red-500">{getVotingStatusMessage()}</p>
             )}
         </div>
     );

--- a/app/day-three/page.tsx
+++ b/app/day-three/page.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button';
 import { useRouter } from 'next/navigation';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { useEffect, useState } from 'react';
+import { isVotingOpenForPosition, ELECTION_SCHEDULE } from '../vote/page';
 
 export default function DayOne() {
     const router = useRouter();
@@ -24,6 +25,28 @@ export default function DayOne() {
 
     const handleVoteClick = (position: string) => {
         router.push(`/vote?position=${encodeURIComponent(position)}`);
+    };
+
+    const getVotingStatusMessage = () => {
+        const position = 'financial-secretary'; // Example position, adjust as needed
+        if (!position || !ELECTION_SCHEDULE[position.toLowerCase()]) {
+            return "Invalid position";
+        }
+        
+        const schedule = ELECTION_SCHEDULE[position.toLowerCase()];
+        const currentDate = new Date();
+        const votingDate = new Date(currentDate.getFullYear(), 0, schedule.date);
+        const today = new Date();
+        
+        if (today.getDate() === schedule.date && today.getMonth() === 0) {
+            if (!isVotingOpen) {
+                return "Voting is only open from 8 AM to 8 PM";
+            }
+        } else if (today < votingDate) {
+            return `Voting for this position opens on January ${schedule.date}`;
+        } else {
+            return `Voting for this position has ended`;
+        }
     };
 
     return (
@@ -73,7 +96,7 @@ export default function DayOne() {
                     </Button>
                 </div>
             ) : (
-                <p className="text-xl text-center text-red-500">Voting closed/voting not open yet</p>
+                <p className="text-xl text-center text-red-500">{getVotingStatusMessage()}</p>
             )}
         </div>
     );

--- a/app/day-two/page.tsx
+++ b/app/day-two/page.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button';
 import { useRouter } from 'next/navigation';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { useEffect, useState } from 'react';
+import { isVotingOpenForPosition, ELECTION_SCHEDULE } from '../vote/page';
 
 export default function DayOne() {
     const router = useRouter();
@@ -24,6 +25,28 @@ export default function DayOne() {
 
     const handleVoteClick = (position: string) => {
         router.push(`/vote?position=${encodeURIComponent(position)}`);
+    };
+
+    const getVotingStatusMessage = () => {
+        const position = 'secretary-general'; // Example position, adjust as needed
+        if (!position || !ELECTION_SCHEDULE[position.toLowerCase()]) {
+            return "Invalid position";
+        }
+        
+        const schedule = ELECTION_SCHEDULE[position.toLowerCase()];
+        const currentDate = new Date();
+        const votingDate = new Date(currentDate.getFullYear(), 0, schedule.date);
+        const today = new Date();
+        
+        if (today.getDate() === schedule.date && today.getMonth() === 0) {
+            if (!isVotingOpen) {
+                return "Voting is only open from 8 AM to 8 PM";
+            }
+        } else if (today < votingDate) {
+            return `Voting for this position opens on January ${schedule.date}`;
+        } else {
+            return `Voting for this position has ended`;
+        }
     };
 
     return (
@@ -73,7 +96,7 @@ export default function DayOne() {
                     </Button>
                 </div>
             ) : (
-                <p className="text-xl text-center text-red-500">Voting closed/voting not open yet</p>
+                <p className="text-xl text-center text-red-500">{getVotingStatusMessage()}</p>
             )}
         </div>
     );


### PR DESCRIPTION
Update voting status messages in day pages to provide more useful information.

* Import `isVotingOpenForPosition` and `ELECTION_SCHEDULE` from `app/vote/page.tsx` in `app/day-five/page.tsx`, `app/day-four/page.tsx`, `app/day-one/page.tsx`, `app/day-three/page.tsx`, and `app/day-two/page.tsx`.
* Add a function `getVotingStatusMessage` in each of the above files to provide detailed voting status messages.
* Replace the existing "Voting closed/voting not open yet" message with the new detailed message in each of the above files.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Daheer/awtthn/pull/8?shareId=43c64005-bd3f-420a-b902-e66ac8a148a2).